### PR TITLE
Avoid clock adjust false error condition

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-ntp-clock-adjust
+++ b/root/etc/e-smith/events/actions/nethserver-ntp-clock-adjust
@@ -36,7 +36,8 @@ my $status = $db->get_prop('chronyd', 'status') || '';
 if($status ne 'enabled') { 
     # manual date setting
     if( ! defined $ts) {
-	die("No timestamp specified");
+        warn("[NOTICE] No timestamp specified, nothing to do.");
+        exit(0);
     }
 
     # Set the system time and hardware clock


### PR DESCRIPTION
clock-adjust: clean exit if timestamp is missing. It is a normal
condition if ntp has been disabled and the update event runs.